### PR TITLE
Update dependencies to address yanked `mozjpeg-sys` version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ uvc-sys = { path = "uvc-sys", version = "0.3.0" }
 glium = "0.29.0"
 
 [features]
-default = ["vendor"]
 vendor = ["uvc-sys/vendor"]
 uvc_debugging = ["uvc-sys/uvc_debugging"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ uvc-sys = { path = "uvc-sys", version = "0.3.0" }
 glium = "0.29.0"
 
 [features]
+default = ["vendor"]
 vendor = ["uvc-sys/vendor"]
 uvc_debugging = ["uvc-sys/uvc_debugging"]
 

--- a/uvc-src/Cargo.toml
+++ b/uvc-src/Cargo.toml
@@ -14,8 +14,8 @@ jpeg = ["mozjpeg-sys"]
 uvc_debugging = []
 
 [dependencies]
-mozjpeg-sys = { version = "0.10.4", default-features = false, optional = true }
-libusb-sys = { version = "0.4.2", package = "libusb1-sys" }
+mozjpeg-sys = { version = "2.2.1", default-features = false, optional = true }
+libusb-sys = { version = "0.7.0", package = "libusb1-sys" }
 
 [build-dependencies]
 cc = "1.0.61"

--- a/uvc-sys/build.rs
+++ b/uvc-sys/build.rs
@@ -4,6 +4,8 @@ use std::env;
 use std::path::PathBuf;
 
 fn main() {
+    let target_triple = env::var("TARGET").unwrap();
+
     let mut includedir = None;
     if std::env::var_os("CARGO_FEATURE_VENDOR").is_some() {
         includedir = Some(std::env::var("DEP_UVCSRC_INCLUDE").unwrap());
@@ -24,6 +26,9 @@ fn main() {
         .header("wrapper.h")
         .allowlist_function("uvc_.*")
         .allowlist_type("uvc_.*")
+        .clang_args([
+            "-target", &target_triple,
+        ])
         .generate()
         .expect("Failed to generate bindings");
 


### PR DESCRIPTION
This PR updates dependencies to replace a yanked version:
- update `mozjpeg-sys` to v2.2.1 since [v0.10.4 is yanked](https://crates.io/crates/mozjpeg-sys/1.0.4)
- update `libusb-sys` to v0.7.0